### PR TITLE
Small refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: php
 
 php:
-  - 5.5.9
-  - 5.5
-  - 5.6
-  - 7.1
+  - 7.0
 
 env:
   global:
@@ -12,7 +9,7 @@ env:
 
 matrix:
   include:
-    - php: 5.5.9
+    - php: 7.0
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "psr-4": {"MichaelAChrisco\\ReadOnly\\": "src/"}
     },
     "require": {
-      "php": ">=5.5.9"
+      "php": ">=7.0.0"
     },
     "require-dev": {
         "kahlan/kahlan": "^2.4",

--- a/spec/ReadOnlyTraitSpec.php
+++ b/spec/ReadOnlyTraitSpec.php
@@ -1,9 +1,8 @@
 <?php
 require_once('src/ReadOnlyTrait.php');
-use MichaelAChrisco\ReadOnly\ReadOnlyException,
-    MichaelAChrisco\ReadOnly\ReadOnlyTrait,
-    Illuminate\Database\Eloquent\Model;
-// use Illuminate\Database\Eloquent\Builder;
+
+use MichaelAChrisco\ReadOnly\ReadOnlyException;
+use MichaelAChrisco\ReadOnly\ReadOnlyTrait;
 
 class User extends Illuminate\Database\Eloquent\Model {
   use ReadOnlyTrait;
@@ -16,7 +15,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->create([]);
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [create] method on read-only model [User] is not allowed.'));
     });
  });
  describe("::forceCreate()", function(){
@@ -25,7 +24,7 @@ describe("User", function() {
        $user = new User;
        $user->forceCreate([]);
      };
-     expect($closure)->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+     expect($closure)->toThrow(new ReadOnlyException('Calling [forceCreate] method on read-only model [User] is not allowed.'));
    });
 });
   describe("::save()", function(){
@@ -34,7 +33,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->save([]);
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [save] method on read-only model [User] is not allowed.'));
     });
   });
   describe("::update()", function(){
@@ -43,7 +42,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->update([]);
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [update] method on read-only model [User] is not allowed.'));
       });
    });
   describe("::firstOrCreate()", function(){
@@ -52,7 +51,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->firstOrCreate([]);
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [firstOrCreate] method on read-only model [User] is not allowed.'));
     });
   });
   describe("::firstOrNew()", function(){
@@ -61,7 +60,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->firstOrNew([]);
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [firstOrNew] method on read-only model [User] is not allowed.'));
     });
    });
   describe("::delete()", function(){
@@ -70,7 +69,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->delete();
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [delete] method on read-only model [User] is not allowed.'));
     });
    });
   describe("::destroy()", function(){
@@ -79,7 +78,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->destroy(1);
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [destroy] method on read-only model [User] is not allowed.'));
     });
    });
   describe("::restore()", function(){
@@ -88,7 +87,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->restore();
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [restore] method on read-only model [User] is not allowed.'));
     });
    });
   describe("::forceDelete()", function(){
@@ -97,7 +96,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->forceDelete();
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [forceDelete] method on read-only model [User] is not allowed.'));
       });
     });
    describe("::performDeleteOnModel()", function(){
@@ -106,7 +105,7 @@ describe("User", function() {
          function(){
            $user = new User;
            $user->performDeleteOnModel();
-         })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+         })->toThrow(new ReadOnlyException('Calling [performDeleteOnModel] method on read-only model [User] is not allowed.'));
       });
     });
   describe("::push()", function(){
@@ -115,7 +114,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->push();
-        })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+        })->toThrow(new ReadOnlyException('Calling [push] method on read-only model [User] is not allowed.'));
      });
    });
  describe("::finishSave()", function(){
@@ -124,7 +123,7 @@ describe("User", function() {
        function(){
          $user = new User;
          $user->finishSave([]);
-       })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+       })->toThrow(new ReadOnlyException('Calling [finishSave] method on read-only model [User] is not allowed.'));
      });
   });
   describe("::performUpdate()", function(){
@@ -142,7 +141,7 @@ describe("User", function() {
          function(){
            $user = new User;
            $user->touch();
-         })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+         })->toThrow(new ReadOnlyException('Calling [touch] method on read-only model [User] is not allowed.'));
       });
     });
    describe("::truncate()", function(){
@@ -151,7 +150,7 @@ describe("User", function() {
          function(){
            $user = new User;
            $user->truncate();
-         })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+         })->toThrow(new ReadOnlyException('Calling [truncate] method on read-only model [User] is not allowed.'));
       });
     });
    describe("::insert()", function(){
@@ -160,10 +159,7 @@ describe("User", function() {
          function(){
            $user = new User;
            $user->insert();
-         })->toThrow(new ReadOnlyException("Not allowed to persist changes in read-only model User"));
+         })->toThrow(new ReadOnlyException('Calling [insert] method on read-only model [User] is not allowed.'));
       });
     });
 });
-
-
- ?>

--- a/spec/ReadOnlyTraitSpec.php
+++ b/spec/ReadOnlyTraitSpec.php
@@ -15,7 +15,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->create([]);
-        })->toThrow(new ReadOnlyException('Calling [create] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('create', 'User'));
     });
  });
  describe("::forceCreate()", function(){
@@ -24,7 +24,7 @@ describe("User", function() {
        $user = new User;
        $user->forceCreate([]);
      };
-     expect($closure)->toThrow(new ReadOnlyException('Calling [forceCreate] method on read-only model [User] is not allowed.'));
+     expect($closure)->toThrow(new ReadOnlyException('forceCreate', 'User'));
    });
 });
   describe("::save()", function(){
@@ -33,7 +33,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->save([]);
-        })->toThrow(new ReadOnlyException('Calling [save] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('save', 'User'));
     });
   });
   describe("::update()", function(){
@@ -42,7 +42,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->update([]);
-        })->toThrow(new ReadOnlyException('Calling [update] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('update', 'User'));
       });
    });
   describe("::firstOrCreate()", function(){
@@ -51,7 +51,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->firstOrCreate([]);
-        })->toThrow(new ReadOnlyException('Calling [firstOrCreate] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('firstOrCreate', 'User'));
     });
   });
   describe("::firstOrNew()", function(){
@@ -60,7 +60,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->firstOrNew([]);
-        })->toThrow(new ReadOnlyException('Calling [firstOrNew] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('firstOrNew', 'User'));
     });
    });
   describe("::delete()", function(){
@@ -69,7 +69,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->delete();
-        })->toThrow(new ReadOnlyException('Calling [delete] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('delete', 'User'));
     });
    });
   describe("::destroy()", function(){
@@ -78,7 +78,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->destroy(1);
-        })->toThrow(new ReadOnlyException('Calling [destroy] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('destroy', 'User'));
     });
    });
   describe("::restore()", function(){
@@ -87,7 +87,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->restore();
-        })->toThrow(new ReadOnlyException('Calling [restore] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('restore', 'User'));
     });
    });
   describe("::forceDelete()", function(){
@@ -96,7 +96,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->forceDelete();
-        })->toThrow(new ReadOnlyException('Calling [forceDelete] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('forceDelete', 'User'));
       });
     });
    describe("::performDeleteOnModel()", function(){
@@ -105,7 +105,7 @@ describe("User", function() {
          function(){
            $user = new User;
            $user->performDeleteOnModel();
-         })->toThrow(new ReadOnlyException('Calling [performDeleteOnModel] method on read-only model [User] is not allowed.'));
+         })->toThrow(new ReadOnlyException('performDeleteOnModel', 'User'));
       });
     });
   describe("::push()", function(){
@@ -114,7 +114,7 @@ describe("User", function() {
         function(){
           $user = new User;
           $user->push();
-        })->toThrow(new ReadOnlyException('Calling [push] method on read-only model [User] is not allowed.'));
+        })->toThrow(new ReadOnlyException('push', 'User'));
      });
    });
  describe("::finishSave()", function(){
@@ -123,7 +123,7 @@ describe("User", function() {
        function(){
          $user = new User;
          $user->finishSave([]);
-       })->toThrow(new ReadOnlyException('Calling [finishSave] method on read-only model [User] is not allowed.'));
+       })->toThrow(new ReadOnlyException('finishSave', 'User'));
      });
   });
   describe("::performUpdate()", function(){
@@ -141,7 +141,7 @@ describe("User", function() {
          function(){
            $user = new User;
            $user->touch();
-         })->toThrow(new ReadOnlyException('Calling [touch] method on read-only model [User] is not allowed.'));
+         })->toThrow(new ReadOnlyException('touch', 'User'));
       });
     });
    describe("::truncate()", function(){
@@ -150,7 +150,7 @@ describe("User", function() {
          function(){
            $user = new User;
            $user->truncate();
-         })->toThrow(new ReadOnlyException('Calling [truncate] method on read-only model [User] is not allowed.'));
+         })->toThrow(new ReadOnlyException('truncate', 'User'));
       });
     });
    describe("::insert()", function(){
@@ -159,7 +159,7 @@ describe("User", function() {
          function(){
            $user = new User;
            $user->insert();
-         })->toThrow(new ReadOnlyException('Calling [insert] method on read-only model [User] is not allowed.'));
+         })->toThrow(new ReadOnlyException('insert', 'User'));
       });
     });
 });

--- a/src/ReadOnlyException.php
+++ b/src/ReadOnlyException.php
@@ -3,4 +3,14 @@ namespace MichaelAChrisco\ReadOnly;
 
 class ReadOnlyException extends \RuntimeException
 {
+    /**
+     * @param string $functionName
+     * @param string $modelClassName
+     * {@inheritDoc}
+     */
+    public function __construct(string $functionName, string $modelClassName, int $code = 0, \Throwable $previous = null)
+    {
+        $message = sprintf('Calling [%s] method on read-only model [%s] is not allowed.', $functionName, $modelClassName);
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/ReadOnlyTrait.php
+++ b/src/ReadOnlyTrait.php
@@ -6,186 +6,167 @@ use MichaelAChrisco\ReadOnly\ReadOnlyException;
 
 trait ReadOnlyTrait
 {
-    public static function readOnly($class)
+    /**
+     * Throws ReadOnlyException on create
+     * @param array $attributes
+     * @throws ReadOnlyException
+     */
+    public static function create(array $attributes = [])
     {
-        throw new ReadOnlyException("Not allowed to persist changes in read-only model {$class}");
-    }
-
-  /**
-   * throws ReadOnlyException on create
-   * @method create
-   * @param  array $attributes
-   *
-   */
-  public static function create(array $attributes = [])
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-/**
- * throws ReadOnlyException on forceCreate
- * @method forceCreate
- * @param  array       $attributes
- *
- */
-  public static function forceCreate(array $attributes)
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-  /**
-   * throws ReadOnlyException on save
-   * @method save
-   * @param  array $options
-   *
-   */
-  public function save(array $options = [])
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-/**
- * throws ReadOnlyException on update
- * @method update
- * @param  [type] $attributes
- * @param   $options
- *
- */
-  public function update(array $attributes = [], array $options = [])
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-/**
- * throws ReadOnlyException on firstOrCreate
- * @method firstOrCreate
- * @param  array         $arr
- *
- */
-  public static function firstOrCreate(array $arr)
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-/**
- * throws ReadOnlyException on firstOrNew
- * @method firstOrNew
- * @param  array      $arr
- *
- */
-  public static function firstOrNew(array $arr)
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-/**
- * throws ReadOnlyException on delete
- * @method delete
- *
- */
-  public function delete()
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-/**
- * throws ReadOnlyException on destroy
- * @method destroy
- * @param  mixed  $ids
- *
- */
-  public static function destroy($ids)
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-/**
- * throws ReadOnlyException on restore
- * @method restore
- *
- */
-  public function restore()
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-/**
- * throws ReadOnlyException on forceDelete
- * @method forceDelete
- *
- */
-  public function forceDelete()
-  {
-      ReadOnlyTrait::readOnly(get_called_class());
-  }
-
-  /**
-   * throws ReadOnlyException on performDeleteOnModel
-   * @method performDeleteOnModel
-   *
-   */
-    public function performDeleteOnModel()
-    {
-        ReadOnlyTrait::readOnly(get_called_class());
-    }
-
-  /**
-   * throws ReadOnlyException on push
-   * @method push
-   *
-   */
-    public function push()
-    {
-        ReadOnlyTrait::readOnly(get_called_class());
-    }
-
-  /**
-   * throws ReadOnlyException on finishSave
-   * @method finishSave
-   *
-   */
-    public function finishSave(array $options)
-    {
-        ReadOnlyTrait::readOnly(get_called_class());
-    }
-
-  /**
-   * throws ReadOnlyException on performUpdate
-   * @method performUpdate
-   *
-   */
-    public function performUpdate(Builder $query, array $options = [])
-    {
-        ReadOnlyTrait::readOnly(get_called_class());
-    }
-
-  /**
-   * throws ReadOnlyException on touch
-   * @method touch
-   *
-   */
-    public function touch()
-    {
-        ReadOnlyTrait::readOnly(get_called_class());
-    }
-
-   /**
-   * throws ReadOnlyException on insert
-   * @method insert
-   *
-   */
-    public function insert()
-    {
-        ReadOnlyTrait::readOnly(get_called_class());
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
     }
 
     /**
-   * throws ReadOnlyException on truncate
-   * @method truncate
-   *
-   */
+     * Throws ReadOnlyException on forceCreate
+     * @param array $attributes
+     * @throws ReadOnlyException
+     */
+    public static function forceCreate(array $attributes)
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on save
+     * @param array $options
+     * @throws ReadOnlyException
+     */
+    public function save(array $options = [])
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on update
+     * @param array $attributes
+     * @param array $options
+     * @throws ReadOnlyException
+     */
+    public function update(array $attributes = [], array $options = [])
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on firstOrCreate
+     * @param array $arr
+     * @throws ReadOnlyException
+     */
+    public static function firstOrCreate(array $arr)
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on firstOrNew
+     * @param array $arr
+     * @throws ReadOnlyException
+     */
+    public static function firstOrNew(array $arr)
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on delete
+     * @throws ReadOnlyException
+     */
+    public function delete()
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on destroy
+     * @param mixed $ids
+     * @throws ReadOnlyException
+     */
+    public static function destroy($ids)
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on restore
+     * @throws ReadOnlyException
+     */
+    public function restore()
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on forceDelete
+     * @throws ReadOnlyException
+     */
+    public function forceDelete()
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on performDeleteOnModel
+     * @throws ReadOnlyException
+     */
+    public function performDeleteOnModel()
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on push
+     * @throws ReadOnlyException
+     */
+    public function push()
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on finishSave
+     * @param array $options
+     * @throws ReadOnlyException
+     */
+    public function finishSave(array $options)
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on performUpdate
+     * @param Builder $query
+     * @param array $options
+     * @throws ReadOnlyException
+     */
+    public function performUpdate(Builder $query, array $options = [])
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on touch
+     * @throws ReadOnlyException
+     */
+    public function touch()
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on insert
+     * @throws ReadOnlyException
+     */
+    public function insert()
+    {
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
+    }
+
+    /**
+     * Throws ReadOnlyException on truncate
+     * @throws ReadOnlyException
+     */
     public function truncate()
     {
-        ReadOnlyTrait::readOnly(get_called_class());
+        throw new ReadOnlyException(__FUNCTION__, get_called_class());
     }
 }


### PR DESCRIPTION
1. Formatting code to PSR-2 Standard
2. Moving building exception message to `ReadOnlyException` constructor.
3. Changed exception message. Using `__FUNCTION__` to determine called function.
4. Fixed wrong php requirement in `composer.json`. Casting params in functions `function(string/int/float/bool $variable)` was added in PHP7.0. 5.5.9 would not handle that.