### PR TITLE
Fix touch signtaure

### DIFF
--- a/src/ReadOnlyTrait.php
+++ b/src/ReadOnlyTrait.php
@@ -158,9 +158,10 @@ trait ReadOnlyTrait
 
     /**
      * Throws ReadOnlyException on touch
+     * @param  string|null  $attribute
      * @throws ReadOnlyException
      */
-    public function touch()
+    public function touch($attribute = null)
     {
         throw new ReadOnlyException(__FUNCTION__, get_called_class());
     }


### PR DESCRIPTION
This fixes the signature of the touch() method on the trait so it matches the Eloquent one. This allowed me to install and use this package with Laravel 8 and 9 on PHP 8.0 and 8.1.