### PR TITLE
Update composer.json - illuminate/database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,6 @@
 version: 2.1
 
 jobs:
-  build_php_version_81:
-    docker:
-      - image: cimg/php:8.1.14
-    working_directory: ~/ReadOnlyTraitLaravel
-    steps: # a set of executable commands
-      - checkout
-      - run: sudo composer self-update
-      - run: composer install -n --prefer-dist --no-plugins
-      - run: ./vendor/bin/kahlan -reporter=verbose
   build_php_version_82:
     docker: 
       - image: cimg/php:8.2.12
@@ -32,6 +23,5 @@ workflows:
   version: 2
   build:
     jobs:
-      - build_php_version_81
       - build_php_version_82
       - build_php_version_83

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     },
     "require-dev": {
         "kahlan/kahlan": "^5.2.5",
-        "illuminate/database": "=10.29.0"
+        "illuminate/database": "=11.1.0"
     }
 }


### PR DESCRIPTION
Update illuminate/database to latest version: [11.1.0](https://github.com/illuminate/database/releases/tag/v11.1.0)

Latest version of illuminate/database requires > PHP 8.1, so removed CI on php 8.1. Its only going to be supported for a couple of months anyways.  

Closes #58 